### PR TITLE
Little enhancement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM rabbitmq:${RABBITMQ_VERSION}-management-alpine
 
 ENV RABBITMQ_ERLANG_COOKIE="cookiemonster"
 
-RUN chgrp -R root /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq
-RUN chmod g+w /etc/passwd
-RUN chmod -R g+rwx /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq
+RUN chgrp -R root /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq &&\
+    chmod g+w /etc/passwd &&\
+    chmod -R g+rwx /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq
 
 ADD launch.sh /launch.sh
 VOLUME /var/lib/rabbitmq


### PR DESCRIPTION
When I was looking at Dockerfile, I did not quite understand why would there be a different RUN for each of layers being created. I would think that having this would be better:
```
RUN  chgrp -R root /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq &&\
     chmod g+w /etc/passwd &&\
     chmod -R g+rwx /var/lib/rabbitmq /var/log/rabbitmq /etc/rabbitmq
```