### PR TITLE
Force boot rabbit if mnesia database already exists

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -12,4 +12,8 @@ fi
 echo "$RABBITMQ_ERLANG_COOKIE" > $HOME/.erlang.cookie
 chmod 0600 $HOME/.erlang.cookie
 
+if [ "$RABBITMQ_NODENAME" ]; then
+    if [ -d "/var/lib/rabbitmq/mnesia/\${RABBITMQ_NODENAME}" ]; then rabbitmqctl force_boot; fi
+fi
+
 docker-entrypoint.sh rabbitmq-server


### PR DESCRIPTION
##### SUMMARY
related https://github.com/ansible/awx/issues/5314

tells rabbit to force_boot if mnesia database already exists, see helm/charts#13485

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
 - Installer

##### AWX VERSION
8.0.0

##### ADDITIONAL INFORMATION

helm/charts#13485